### PR TITLE
fix: address code review issues 2,3,4 and add CI (fix 1 already solved)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
+      - name: Type check (pyright)
+        run: uv run pyright
+
+      - name: Test (pytest)
+        run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --group dev
 
       - name: Lint (ruff)
         run: uv run ruff check .

--- a/scripts/code_review.py
+++ b/scripts/code_review.py
@@ -34,7 +34,7 @@ async def main() -> None:
         ),
     ):
         if hasattr(msg, "result"):
-            print(msg.result)
+            print(msg.result)  # type: ignore[union-attr]
 
 
 if __name__ == "__main__":

--- a/src/agent_interception/proxy/handler.py
+++ b/src/agent_interception/proxy/handler.py
@@ -70,7 +70,7 @@ def redact_headers(headers: dict[str, str], *, redact: bool = True) -> dict[str,
     result = {}
     sensitive_keys = {"authorization", "x-api-key", "api-key", "openai-api-key"}
     for key, value in headers.items():
-        if key.lower() in sensitive_keys:
+        if key.lower() in sensitive_keys or SENSITIVE_HEADER_PATTERNS.search(value):
             # Keep first 8 chars + mask the rest
             if len(value) > 12:
                 result[key] = value[:12] + "***"

--- a/src/agent_interception/proxy/server.py
+++ b/src/agent_interception/proxy/server.py
@@ -100,16 +100,8 @@ def create_app(
         sessions = await store.list_sessions()
         return JSONResponse(sessions)
 
-    async def get_interaction(request: Request) -> Response:
-        """Get a single interaction by ID."""
-        interaction_id = request.path_params["interaction_id"]
-        interaction = await store.get(interaction_id)
-        if interaction is None:
-            return JSONResponse({"error": "Not found"}, status_code=404)
-        return JSONResponse(interaction.model_dump(mode="json"))
-
     async def api_get_interaction(request: Request) -> Response:
-        """API endpoint: get a single interaction by ID (for UI lazy loading)."""
+        """Get a single interaction by ID."""
         interaction_id = request.path_params["interaction_id"]
         interaction = await store.get(interaction_id)
         if interaction is None:
@@ -235,7 +227,7 @@ def create_app(
         Route("/_interceptor/interactions", clear_interactions, methods=["DELETE"]),
         Route(
             "/_interceptor/interactions/{interaction_id}",
-            get_interaction,
+            api_get_interaction,
             methods=["GET"],
         ),
         # UI API endpoints

--- a/src/agent_interception/storage/store.py
+++ b/src/agent_interception/storage/store.py
@@ -911,6 +911,6 @@ class InteractionStore:
                 else None,
             )
         except Exception as exc:
-            row_id = row["id"] if "id" in row.keys() else "<unknown>"
+            row_id = row["id"] if row and "id" in row else "<unknown>"
             logger.warning("Skipping malformed interaction row %s: %s", row_id, exc)
             return None

--- a/src/agent_interception/storage/store.py
+++ b/src/agent_interception/storage/store.py
@@ -293,7 +293,7 @@ class InteractionStore:
 
         cursor = await self.db.execute(query, params)
         rows = await cursor.fetchall()
-        return [self._row_to_interaction(row) for row in rows]
+        return [r for row in rows if (r := self._row_to_interaction(row)) is not None]
 
     async def list_sessions(self) -> list[dict[str, Any]]:
         """List all sessions with summary info.
@@ -368,7 +368,7 @@ class InteractionStore:
             (session_id, limit),
         )
         rows = await cursor.fetchall()
-        return [self._row_to_interaction(row) for row in rows]
+        return [r for row in rows if (r := self._row_to_interaction(row)) is not None]
 
     async def list_conversations(self) -> list[dict[str, Any]]:
         """Return aggregate stats per conversation thread."""
@@ -417,7 +417,7 @@ class InteractionStore:
             (conversation_id,),
         )
         rows = await cursor.fetchall()
-        return [self._row_to_interaction(row) for row in rows]
+        return [r for row in rows if (r := self._row_to_interaction(row)) is not None]
 
     async def clear(self) -> int:
         """Delete all interactions. Returns the number of rows deleted."""
@@ -865,47 +865,52 @@ class InteractionStore:
             "system_prompt_changes": system_prompt_changes,
         }
 
-    def _row_to_interaction(self, row: aiosqlite.Row) -> Interaction:
-        """Convert a database row to an Interaction model."""
-        token_usage_data = _deserialize_json(row["token_usage"])
-        cost_data = _deserialize_json(row["cost_estimate"])
-        image_data = _deserialize_json(row["image_metadata"])
-        chunks_data = _deserialize_json(row["stream_chunks"])
-        context_metrics_data = _deserialize_json(row["context_metrics"])
+    def _row_to_interaction(self, row: aiosqlite.Row) -> Interaction | None:
+        """Convert a database row to an Interaction model. Returns None on deserialization error."""
+        try:
+            token_usage_data = _deserialize_json(row["token_usage"])
+            cost_data = _deserialize_json(row["cost_estimate"])
+            image_data = _deserialize_json(row["image_metadata"])
+            chunks_data = _deserialize_json(row["stream_chunks"])
+            context_metrics_data = _deserialize_json(row["context_metrics"])
 
-        return Interaction(
-            id=row["id"],
-            session_id=row["session_id"],
-            timestamp=row["timestamp"],
-            method=row["method"],
-            path=row["path"],
-            request_headers=json.loads(row["request_headers"]),
-            request_body=_deserialize_json(row["request_body"]),
-            raw_request_body=row["raw_request_body"],
-            provider=Provider(row["provider"]),
-            model=row["model"],
-            system_prompt=row["system_prompt"],
-            messages=_deserialize_json(row["messages"]),
-            tools=_deserialize_json(row["tools"]),
-            image_metadata=ImageMetadata(**image_data) if image_data else None,
-            status_code=row["status_code"],
-            response_headers=json.loads(row["response_headers"]),
-            response_body=_deserialize_json(row["response_body"]),
-            raw_response_body=row["raw_response_body"],
-            is_streaming=bool(row["is_streaming"]),
-            stream_chunks=[StreamChunk(**c) for c in chunks_data] if chunks_data else [],
-            response_text=row["response_text"],
-            tool_calls=_deserialize_json(row["tool_calls"]),
-            token_usage=TokenUsage(**token_usage_data) if token_usage_data else None,
-            cost_estimate=CostEstimate(**cost_data) if cost_data else None,
-            time_to_first_token_ms=row["time_to_first_token_ms"],
-            total_latency_ms=row["total_latency_ms"],
-            error=row["error"],
-            conversation_id=row["conversation_id"],
-            parent_interaction_id=row["parent_interaction_id"],
-            turn_number=row["turn_number"],
-            turn_type=row["turn_type"],
-            context_metrics=ContextMetrics(**context_metrics_data)
-            if context_metrics_data
-            else None,
-        )
+            return Interaction(
+                id=row["id"],
+                session_id=row["session_id"],
+                timestamp=row["timestamp"],
+                method=row["method"],
+                path=row["path"],
+                request_headers=json.loads(row["request_headers"]),
+                request_body=_deserialize_json(row["request_body"]),
+                raw_request_body=row["raw_request_body"],
+                provider=Provider(row["provider"]),
+                model=row["model"],
+                system_prompt=row["system_prompt"],
+                messages=_deserialize_json(row["messages"]),
+                tools=_deserialize_json(row["tools"]),
+                image_metadata=ImageMetadata(**image_data) if image_data else None,
+                status_code=row["status_code"],
+                response_headers=json.loads(row["response_headers"]),
+                response_body=_deserialize_json(row["response_body"]),
+                raw_response_body=row["raw_response_body"],
+                is_streaming=bool(row["is_streaming"]),
+                stream_chunks=[StreamChunk(**c) for c in chunks_data] if chunks_data else [],
+                response_text=row["response_text"],
+                tool_calls=_deserialize_json(row["tool_calls"]),
+                token_usage=TokenUsage(**token_usage_data) if token_usage_data else None,
+                cost_estimate=CostEstimate(**cost_data) if cost_data else None,
+                time_to_first_token_ms=row["time_to_first_token_ms"],
+                total_latency_ms=row["total_latency_ms"],
+                error=row["error"],
+                conversation_id=row["conversation_id"],
+                parent_interaction_id=row["parent_interaction_id"],
+                turn_number=row["turn_number"],
+                turn_type=row["turn_type"],
+                context_metrics=ContextMetrics(**context_metrics_data)
+                if context_metrics_data
+                else None,
+            )
+        except Exception as exc:
+            row_id = row["id"] if "id" in row.keys() else "<unknown>"
+            logger.warning("Skipping malformed interaction row %s: %s", row_id, exc)
+            return None

--- a/tests/test_display/test_charts.py
+++ b/tests/test_display/test_charts.py
@@ -154,7 +154,7 @@ def sample_interactions() -> list[Interaction]:
 def test_latency_over_time_returns_figure(sample_interactions: list[Interaction]) -> None:
     fig = chart_latency_over_time(sample_interactions)
     assert isinstance(fig, go.Figure)
-    assert len(fig.data) >= 1
+    assert len(fig.data) >= 1  # type: ignore[arg-type]
 
 
 def test_latency_over_time_empty() -> None:
@@ -164,7 +164,7 @@ def test_latency_over_time_empty() -> None:
 
 def test_latency_over_time_includes_ttft(sample_interactions: list[Interaction]) -> None:
     fig = chart_latency_over_time(sample_interactions)
-    names = [t.name for t in fig.data]
+    names = [t.name for t in fig.data]  # type: ignore[union-attr]
     assert any("TTFT" in (n or "") for n in names)
 
 
@@ -176,7 +176,7 @@ def test_latency_over_time_includes_ttft(sample_interactions: list[Interaction])
 def test_token_usage_returns_figure(sample_interactions: list[Interaction]) -> None:
     fig = chart_token_usage(sample_interactions)
     assert isinstance(fig, go.Figure)
-    assert len(fig.data) >= 1
+    assert len(fig.data) >= 1  # type: ignore[arg-type]
 
 
 def test_token_usage_empty() -> None:
@@ -198,7 +198,7 @@ def test_token_usage_bar_traces(sample_interactions: list[Interaction]) -> None:
 def test_cumulative_cost_returns_figure(sample_interactions: list[Interaction]) -> None:
     fig = chart_cumulative_cost(sample_interactions)
     assert isinstance(fig, go.Figure)
-    assert len(fig.data) >= 1
+    assert len(fig.data) >= 1  # type: ignore[arg-type]
 
 
 def test_cumulative_cost_empty() -> None:
@@ -216,7 +216,7 @@ def test_cumulative_cost_monotonically_nondecreasing(
     shuffled = list(sample_interactions)
     random.shuffle(shuffled)
     fig = chart_cumulative_cost(shuffled)
-    y_values = list(fig.data[0].y)
+    y_values = list(fig.data[0].y)  # type: ignore[union-attr]
     for a, b in itertools.pairwise(y_values):
         assert b >= a, f"Cumulative cost decreased: {a} -> {b}"
 
@@ -229,7 +229,7 @@ def test_cumulative_cost_monotonically_nondecreasing(
 def test_provider_distribution_returns_figure(sample_interactions: list[Interaction]) -> None:
     fig = chart_provider_distribution(sample_interactions)
     assert isinstance(fig, go.Figure)
-    assert len(fig.data) >= 1
+    assert len(fig.data) >= 1  # type: ignore[arg-type]
 
 
 def test_provider_distribution_empty() -> None:
@@ -262,7 +262,7 @@ def test_provider_distribution_bar_for_few_providers() -> None:
 def test_context_window_growth_returns_figure(sample_interactions: list[Interaction]) -> None:
     fig = chart_context_window_growth(sample_interactions)
     assert isinstance(fig, go.Figure)
-    assert len(fig.data) >= 1
+    assert len(fig.data) >= 1  # type: ignore[arg-type]
 
 
 def test_context_window_growth_empty() -> None:
@@ -278,7 +278,7 @@ def test_context_window_growth_excludes_no_context() -> None:
     ]
     fig = chart_context_window_growth(interactions)
     # Should have at least 1 trace with data
-    assert any(len(t.y) > 0 for t in fig.data if hasattr(t, "y") and t.y is not None)
+    assert any(len(t.y) > 0 for t in fig.data if hasattr(t, "y") and t.y is not None)  # type: ignore[union-attr]
 
 
 def test_context_window_growth_caps_at_20_traces() -> None:
@@ -294,8 +294,8 @@ def test_context_window_growth_caps_at_20_traces() -> None:
         )
     fig = chart_context_window_growth(interactions)
     # Should have 20 named traces + 1 "other" trace = 21 total
-    assert len(fig.data) == 21
-    other_traces = [t for t in fig.data if t.name == "other"]
+    assert len(fig.data) == 21  # type: ignore[arg-type]
+    other_traces = [t for t in fig.data if t.name == "other"]  # type: ignore[union-attr]
     assert len(other_traces) == 1
 
 
@@ -307,7 +307,7 @@ def test_context_window_growth_caps_at_20_traces() -> None:
 def test_latency_histogram_returns_figure(sample_interactions: list[Interaction]) -> None:
     fig = chart_latency_histogram(sample_interactions)
     assert isinstance(fig, go.Figure)
-    assert len(fig.data) >= 1
+    assert len(fig.data) >= 1  # type: ignore[arg-type]
 
 
 def test_latency_histogram_empty() -> None:

--- a/tests/test_proxy/test_fake_responses.py
+++ b/tests/test_proxy/test_fake_responses.py
@@ -14,7 +14,7 @@ class TestBuildSessionRequiredResponse:
     def test_anthropic_format(self) -> None:
         resp = build_session_required_response(Provider.ANTHROPIC)
         assert resp.status_code == 200
-        body = json.loads(resp.body)
+        body = json.loads(bytes(resp.body))
         assert body["type"] == "message"
         assert body["role"] == "assistant"
         assert len(body["content"]) == 1
@@ -25,7 +25,7 @@ class TestBuildSessionRequiredResponse:
     def test_openai_format(self) -> None:
         resp = build_session_required_response(Provider.OPENAI)
         assert resp.status_code == 200
-        body = json.loads(resp.body)
+        body = json.loads(bytes(resp.body))
         assert body["object"] == "chat.completion"
         assert len(body["choices"]) == 1
         msg = body["choices"][0]["message"]
@@ -36,7 +36,7 @@ class TestBuildSessionRequiredResponse:
     def test_ollama_format(self) -> None:
         resp = build_session_required_response(Provider.OLLAMA)
         assert resp.status_code == 200
-        body = json.loads(resp.body)
+        body = json.loads(bytes(resp.body))
         assert body["done"] is True
         assert body["message"]["role"] == "assistant"
         assert "/_session/" in body["message"]["content"]
@@ -44,20 +44,20 @@ class TestBuildSessionRequiredResponse:
     def test_unknown_format(self) -> None:
         resp = build_session_required_response(Provider.UNKNOWN)
         assert resp.status_code == 200
-        body = json.loads(resp.body)
+        body = json.loads(bytes(resp.body))
         assert "error" in body
         assert body["error"]["code"] == -32000
         assert "/_session/" in body["error"]["message"]
 
     def test_custom_host_in_message(self) -> None:
         resp = build_session_required_response(Provider.ANTHROPIC, host="myhost:9090")
-        body = json.loads(resp.body)
+        body = json.loads(bytes(resp.body))
         text = body["content"][0]["text"]
         assert "myhost:9090" in text
         assert "http://myhost:9090/_session/" in text
 
     def test_default_host(self) -> None:
         resp = build_session_required_response(Provider.OPENAI)
-        body = json.loads(resp.body)
+        body = json.loads(bytes(resp.body))
         text = body["choices"][0]["message"]["content"]
         assert "localhost:8080" in text

--- a/tests/test_proxy/test_handler.py
+++ b/tests/test_proxy/test_handler.py
@@ -108,7 +108,7 @@ class TestSessionGuard:
             ],
         }
 
-        async def receive() -> dict[str, bytes]:
+        async def receive() -> dict[str, object]:
             body = json.dumps({"model": "claude-sonnet-4-20250514", "messages": []}).encode()
             return {"type": "http.request", "body": body}
 
@@ -118,7 +118,7 @@ class TestSessionGuard:
         response = await handler.handle(request)
 
         assert response.status_code == 200
-        body = json.loads(response.body)
+        body = json.loads(bytes(response.body))
         assert body["type"] == "message"
         assert "/_session/" in body["content"][0]["text"]
 
@@ -144,7 +144,7 @@ class TestSessionGuard:
             ],
         }
 
-        async def receive() -> dict[str, bytes]:
+        async def receive() -> dict[str, object]:
             body = json.dumps({"model": "gpt-4", "messages": []}).encode()
             return {"type": "http.request", "body": body}
 
@@ -154,7 +154,7 @@ class TestSessionGuard:
         response = await handler.handle(request)
 
         assert response.status_code == 200
-        body = json.loads(response.body)
+        body = json.loads(bytes(response.body))
         assert body["object"] == "chat.completion"
         assert "/_session/" in body["choices"][0]["message"]["content"]
 
@@ -177,7 +177,7 @@ class TestSessionGuard:
             ],
         }
 
-        async def receive() -> dict[str, bytes]:
+        async def receive() -> dict[str, object]:
             body = json.dumps({"model": "claude-sonnet-4-20250514", "messages": []}).encode()
             return {"type": "http.request", "body": body}
 
@@ -191,7 +191,7 @@ class TestSessionGuard:
         # The key assertion: the response was NOT our fake session-required message.
         # If status_code is 200, verify the body isn't our fake response.
         if response.status_code == 200:
-            body = json.loads(response.body)
+            body = json.loads(bytes(response.body))
             assert body.get("model") != "interceptor-proxy"
         else:
             # Any non-200 means the request was forwarded upstream (correct behavior)
@@ -217,7 +217,7 @@ class TestSessionGuard:
             ],
         }
 
-        async def receive() -> dict[str, bytes]:
+        async def receive() -> dict[str, object]:
             body = json.dumps({"model": "claude-sonnet-4-20250514", "messages": []}).encode()
             return {"type": "http.request", "body": body}
 
@@ -228,7 +228,7 @@ class TestSessionGuard:
 
         # The key assertion: the response was NOT our fake session-required message.
         if response.status_code == 200:
-            body = json.loads(response.body)
+            body = json.loads(bytes(response.body))
             assert body.get("model") != "interceptor-proxy"
         else:
             assert response.status_code != 200

--- a/tests/test_proxy/test_handler.py
+++ b/tests/test_proxy/test_handler.py
@@ -45,6 +45,26 @@ class TestRedactHeaders:
         result = redact_headers(headers)
         assert result["x-api-key"] == "***"
 
+    def test_redacts_api_key_in_non_standard_header_value(self) -> None:
+        """API key pattern in a non-standard header name should still be redacted."""
+        headers = {"x-custom-token": "sk-abc123defghijklmno"}
+        result = redact_headers(headers)
+        assert result["x-custom-token"].endswith("***")
+        assert "sk-abc123defghijklmno" not in result["x-custom-token"]
+
+    def test_redacts_bearer_token_in_non_standard_header_value(self) -> None:
+        """Bearer token in a non-standard header name should still be redacted."""
+        headers = {"x-forwarded-auth": "Bearer supersecrettoken123"}
+        result = redact_headers(headers)
+        assert result["x-forwarded-auth"].endswith("***")
+        assert "supersecrettoken123" not in result["x-forwarded-auth"]
+
+    def test_preserves_non_sensitive_value_in_custom_header(self) -> None:
+        """Non-sensitive values in custom headers should be left alone."""
+        headers = {"x-request-id": "abc-123-def"}
+        result = redact_headers(headers)
+        assert result["x-request-id"] == "abc-123-def"
+
 
 @pytest.fixture
 async def handler_deps(

--- a/tests/test_storage/test_store.py
+++ b/tests/test_storage/test_store.py
@@ -205,6 +205,47 @@ async def test_no_session_saved_as_orphan(store: InteractionStore) -> None:
 
 
 @pytest.mark.asyncio
+async def test_malformed_row_skipped_in_list(
+    store: InteractionStore, sample_interaction: Interaction
+) -> None:
+    """A malformed DB row should be skipped without crashing list_interactions."""
+    await store.save(sample_interaction)
+
+    # Corrupt the request_headers column of the saved row to invalid JSON
+    await store.db.execute(
+        "UPDATE interactions SET request_headers = 'not-valid-json' WHERE id = ?",
+        (sample_interaction.id,),
+    )
+    await store.db.commit()
+
+    # Should return an empty list instead of raising
+    results = await store.list_interactions()
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_malformed_row_does_not_affect_other_rows(
+    store: InteractionStore,
+    sample_interaction: Interaction,
+    sample_streaming_interaction: Interaction,
+) -> None:
+    """A malformed row should be skipped; valid rows in the same query are still returned."""
+    await store.save(sample_interaction)
+    await store.save(sample_streaming_interaction)
+
+    # Corrupt only the first interaction
+    await store.db.execute(
+        "UPDATE interactions SET request_headers = 'not-valid-json' WHERE id = ?",
+        (sample_interaction.id,),
+    )
+    await store.db.commit()
+
+    results = await store.list_interactions()
+    assert len(results) == 1
+    assert results[0].id == sample_streaming_interaction.id
+
+
+@pytest.mark.asyncio
 async def test_no_session_does_not_link_to_previous(store: InteractionStore) -> None:
     """Two interactions without session_id should NOT be linked via global search."""
     first = Interaction(


### PR DESCRIPTION
fix: address code review issues 2, 3, 4 and add CI                                                        
                                                    
  - Issue 2: wire SENSITIVE_HEADER_PATTERNS into redact_headers() so API                                    
    keys in non-standard header values are redacted, not just known header names                            
  - Issue 3: wrap _row_to_interaction in try/except; malformed rows are         
    logged and skipped so one bad row no longer crashes list queries                                        
  - Issue 4: remove duplicate get_interaction; both /_interceptor and                                       
    /api routes now point to api_get_interaction                     
  - CI: add .github/workflows/ci.yml running ruff, pyright, and pytest                                      
    on every push and PR to master  